### PR TITLE
feat: add data versioning

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -186,6 +186,7 @@ const buildConfig = (env) => {
             // Add support for environment variables under `process.env`
             new DefinePlugin({
                 'process.env.NODE_ENV': `"${env}"`,
+                DATA_VERSIONS: JSON.stringify(require('../package.json').dataVersions),
             }),
             // Alleviate cases where developers working on OSX, which does not follow strict path case sensitivity
             new CaseSensitivePathsPlugin(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@discussify/browser-extension",
   "version": "0.0.1",
+  "dataVersions": {
+    "discussions": "1"
+  },
   "private": true,
   "dependencies": {
     "@discussify/styleguide": "^0.5.0",

--- a/src/extension-background/store/discussions/util/collaboration-names.js
+++ b/src/extension-background/store/discussions/util/collaboration-names.js
@@ -1,1 +1,4 @@
-export const getCommentsCollaborationName = (discussionId) => `discussion-comments-${discussionId}`;
+/* global DATA_VERSIONS */
+
+// We are appending DATA_VERSIONS to collaboration name so that discussions are reset every time data structure changes
+export const getCommentsCollaborationName = (discussionId) => `discussion-comments-${discussionId}-${DATA_VERSIONS.discussions}`;


### PR DESCRIPTION
This PR suffixes `discussion comments name` with `DATA_VERSION.discussions` so that discussions are reset everytime data structure changes. 

`DATA_VERSION` object is defined on `package.json` and looks like:
```json
"dataVersions": {
    "discussions": "1"
  }
```