### PR TITLE
Add "how to get started" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Because the current version is a pre-alpha, it's not yet available through the r
 
 1. Point to the folder where you extracted the ZIP contents
 
-The extension should now appear in the extensions list!
+The extension should now appear in the extensions list! Click on the extension icon and then look for the white floating action button in the bottom right of your window to login with a uPort identity and start using Discussify.
+
 
 ### Development
 


### PR DESCRIPTION
I was confused where to look and how to get the discussify sidebar up (I didn't see the white floating action button at all, so I didn't think clicking on the extension was doing anything). To help others, I added a line that would have helped me figure out how to get this working. Even better if we could add an explanatory image or gif to this page, and maybe a tooltip or animation on the discuss button when it first appears to call attention to it.