### PR TITLE
fix: remove logger from store on production

### DIFF
--- a/src/extension-background/store/index.js
+++ b/src/extension-background/store/index.js
@@ -14,8 +14,8 @@ const reducer = combineReducers({
 const configureStore = (peerStarApp, initialState) => {
     const middlewares = [
         thunk.withExtraArgument({ peerStarApp }),
-        ...(process.env.NODE_ENV === 'development' ? [logger] : []),
-    ];
+        process.env.NODE_ENV === 'development' && logger,
+    ].filter(Boolean);
 
     return createStore(reducer, initialState, applyMiddleware(...middlewares));
 };

--- a/src/extension-background/store/index.js
+++ b/src/extension-background/store/index.js
@@ -14,7 +14,7 @@ const reducer = combineReducers({
 const configureStore = (peerStarApp, initialState) => {
     const middlewares = [
         thunk.withExtraArgument({ peerStarApp }),
-        logger,
+        ...(process.env.NODE_ENV === 'development' ? [logger] : []),
     ];
 
     return createStore(reducer, initialState, applyMiddleware(...middlewares));


### PR DESCRIPTION
This PR removes [redux-logger](https://github.com/LogRocket/redux-logger) middleware from the store on `production` environment. 