### PR TITLE
fix: scrolling and layout in Firefox

### DIFF
--- a/src/slices/sidebar/App.css
+++ b/src/slices/sidebar/App.css
@@ -2,8 +2,4 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-
-    & .discussion {
-        flex: 1 0;
-    }
 }

--- a/src/slices/sidebar/App.js
+++ b/src/slices/sidebar/App.js
@@ -50,8 +50,7 @@ class App extends Component {
                     onCommentRemove={ onCommentRemove }
                     onCommentReply={ onCommentReply }
                     onCommentLoad={ onCommentLoad }
-                    onCommentLoadHistory={ onCommentLoadHistory }
-                    className={ styles.discussion } />
+                    onCommentLoadHistory={ onCommentLoadHistory } />
             </div>
         );
     }

--- a/src/slices/sidebar/discussion/Discussion.css
+++ b/src/slices/sidebar/discussion/Discussion.css
@@ -1,8 +1,4 @@
-.discussion {
-    display: flex;
-    flex-direction: column;
-
-    & .commentsList {
-        flex: 1 0;
-    }
+.commentsList {
+    overflow-y: auto;
+    flex: 1 0;
 }

--- a/src/slices/sidebar/discussion/Discussion.js
+++ b/src/slices/sidebar/discussion/Discussion.js
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import { last } from 'lodash';
 import CommentsListError from './comments-list-error';
 import CommentsListEmpty from './comments-list-empty';
@@ -42,16 +41,15 @@ export default class Discussion extends Component {
     }
 
     render() {
-        const { error, commentNodes, className } = this.props;
+        const { error, commentNodes } = this.props;
 
         return (
-            <div className={ classNames(styles.discussion, className) }>
+            <Fragment>
                 { this.renderList() }
-
                 <NewComment
                     disabled={ !error && !commentNodes }
                     onNewComment={ this.handleNewComment } />
-            </div>
+            </Fragment>
         );
     }
 
@@ -89,8 +87,8 @@ export default class Discussion extends Component {
                 onRemove={ onCommentRemove }
                 onReply={ onCommentReply }
                 onLoad={ onCommentLoad }
-                onLoadHistory={ onCommentLoadHistory }
-                className={ styles.commentsList } />
+                className={ styles.commentsList }
+                onLoadHistory={ onCommentLoadHistory } />
         );
     }
 
@@ -122,10 +120,12 @@ export default class Discussion extends Component {
     }
 
     handleNewComment = async (body) => {
-        const previousNode = last(this.props.commentNodes);
+        const { commentNodes, onCommentCreate } = this.props;
+
+        const previousNode = last(commentNodes);
         const previousId = previousNode && previousNode.id;
 
-        const newId = await this.props.onCommentCreate(previousId, body);
+        const newId = await onCommentCreate(previousId, body);
 
         this.setState({ addedCommentId: newId });
     };

--- a/src/slices/sidebar/discussion/comments-list/CommentsList.css
+++ b/src/slices/sidebar/discussion/comments-list/CommentsList.css
@@ -2,7 +2,6 @@
 
 .commentsList {
     position: relative;
-    overflow-y: auto;
     padding: 1.5rem 5rem 1.5rem 3rem;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
This PR addresses the following for Firefox:

- Fixes the position of `TopBar` and `NewComment` where both were not being fixed at the top and bottom of the discussion, respectively, while scrolling upwards and downwards

There is one specific behavior I was unable to retain (yet) in comparison with Chrome. When the `NewComment` input is focused and the discussion is scrolled down to the very bottom, the input is not pushing the discussion upwards as it grows. 

@satazor @PedroMiguelSS any hints on how we could solve this? 🤔
 